### PR TITLE
[chore]: Update API URL to connect to new instance

### DIFF
--- a/client/utils/url-utils.ts
+++ b/client/utils/url-utils.ts
@@ -3,7 +3,7 @@ export function getApiUrl(path: string) {
     return `http://localhost:8080/${path}`;
   }
 
-  return `https://api-thingcast.zeabur.app/${path}`; // replace with your API URL
+  return `https://api-thingcast.vercel.app/${path}`; // replace with your API URL
 }
 export function getAppUrl(path: string) {
   if (process.env.NODE_ENV === "development") {


### PR DESCRIPTION
### TL;DR

Updated the API URL in `url-utils.ts` to `https://api-thingcast.vercel.app/`.

### What changed?

The API URL in the `getApiUrl` function was changed from `https://api-thingcast.zeabur.app/` to `https://api-thingcast.vercel.app/`.

### How to test?

1. Ensure the environment is set to production.
2. Call any API endpoint using the `getApiUrl` function.
3. Verify that requests are made to the new URL (`https://api-thingcast.vercel.app/`).

### Why make this change?

The change was made to update the API provider for the application.